### PR TITLE
Update hyperref style.

### DIFF
--- a/ansarticle.cls
+++ b/ansarticle.cls
@@ -16,7 +16,7 @@
 \RequirePackage{booktabs}
 \RequirePackage{fancyhdr}
 \RequirePackage{graphicx}
-\RequirePackage[hyperfootnotes=false]{hyperref}
+\RequirePackage[hyperfootnotes=false,colorlinks,linkcolor=blue,urlcolor=blue,citecolor=blue]{hyperref}
 \RequirePackage{natbib}
 
 \RequirePackage{lastpage}


### PR DESCRIPTION
The existing stlye uses hyperrefs that are printed with a green box around it.
This no longer conforms to the common styles people use in 2015. Use blue text
instead for things one can click on.
