### PR TITLE
Remove svn $Id:$ tags.

### DIFF
--- a/ansarticle.cls
+++ b/ansarticle.cls
@@ -1,5 +1,3 @@
-% $Id$
-
 % FIXME: (AL) Need to choose a license for this style, I suggest GFDL
 
 % Basic setup

--- a/paper.tex
+++ b/paper.tex
@@ -1,5 +1,3 @@
-% $Id$
-
 \documentclass{ansarticle}
 
 \title{Preparing articles for submission to the \\


### PR DESCRIPTION
We no longer use svn, so these tags have become useless.
